### PR TITLE
Add decorators for checking returns and dates

### DIFF
--- a/portfolio_management/constants/columns.py
+++ b/portfolio_management/constants/columns.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Columns(Enum):
+    DATE = "date"
+    RETURNS = "returns"

--- a/portfolio_management/decorators/dates.py
+++ b/portfolio_management/decorators/dates.py
@@ -1,0 +1,43 @@
+import inspect
+import pandas as pd
+from functools import wraps
+from portfolio_management.constants.columns import Columns
+
+
+def validate_date_column(column_name=Columns.DATE.value):
+    """
+    Validates that a DataFrame contains a valid date column with dates sorted in ascending order.
+
+    Parameters:
+    column_name (str): The name of the date column to validate. Defaults to 'date'.
+
+    Returns:
+    function: A decorator to validate the date column.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            signature = inspect.signature(func)
+            bound_arguments = signature.bind(*args, **kwargs).arguments
+            dataframe = bound_arguments.get("returns")
+
+            if dataframe is not None:
+                if column_name not in dataframe.columns:
+                    raise KeyError(
+                        f"The DataFrame must contain a '{column_name}' column."
+                    )
+                if not pd.api.types.is_datetime64_any_dtype(dataframe[column_name]):
+                    raise ValueError(
+                        f"The '{column_name}' column must be of a datetime type."
+                    )
+                if not dataframe[column_name].is_monotonic_increasing:
+                    raise ValueError(
+                        f"The '{column_name}' column must be sorted in ascending order."
+                    )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/portfolio_management/decorators/returns.py
+++ b/portfolio_management/decorators/returns.py
@@ -1,0 +1,82 @@
+import inspect
+import numpy as np
+import pandas as pd
+from functools import wraps
+
+from portfolio_management.constants.columns import Columns
+from portfolio_management.decorators.dates import validate_date_column
+
+
+def validate_returns(check_dates=True, date_column=Columns.DATE.value):
+    """
+    Validates that a 'returns' parameter is a pd.DataFrame, pd.Series, or list.
+
+    If the 'returns' parameter is a DataFrame, it ensures:
+    - The 'returns' column contains numeric values with no NaNs or None.
+    - The date column, if specified and validation is enabled, is sorted in ascending order.
+
+    Parameters:
+    check_dates (bool): Whether to validate the date column in a DataFrame. Default is True.
+    date_column (str): The name of the date column to validate. Defaults to 'date'.
+
+    Returns:
+    function: A decorator to validate the returns and optionally the date column.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            signature = inspect.signature(func)
+            bound_arguments = signature.bind(*args, **kwargs).arguments
+            returns = bound_arguments.get("returns")
+
+            if returns is None:
+                raise ValueError(
+                    f"A 'returns' parameter must be provided as a pd.DataFrame, pd.Series, or list."
+                )
+
+            if not isinstance(returns, (pd.DataFrame, pd.Series, list)):
+                raise ValueError(
+                    f"The 'returns' parameter must be a pd.DataFrame, pd.Series, or list."
+                )
+
+            if isinstance(returns, pd.DataFrame):
+                if Columns.RETURNS.value not in returns.columns:
+                    raise KeyError(
+                        f"The DataFrame must contain a '{Columns.RETURNS.value}' column."
+                    )
+                if not np.issubdtype(returns[Columns.RETURNS.value].dtype, np.number):
+                    raise ValueError(
+                        f"All elements in the '{Columns.RETURNS.value}' column of the DataFrame must be numeric."
+                    )
+                if returns[Columns.RETURNS.value].isna().any():
+                    raise ValueError(
+                        f"The '{Columns.RETURNS.value}' column in the DataFrame contains NaN or None values."
+                    )
+
+                if check_dates:
+                    validate_date_column(date_column)(func)(*args, **kwargs)
+
+            elif isinstance(returns, pd.Series):
+                if not np.issubdtype(returns.dtype, np.number):
+                    raise ValueError(
+                        f"All elements in the '{Columns.RETURNS.value}' Series must be numeric."
+                    )
+                if returns.isna().any():
+                    raise ValueError(
+                        f"The '{Columns.RETURNS.value}' Series contains NaN or None values."
+                    )
+
+            elif isinstance(returns, list):
+                if (not all(isinstance(x, (int, float)) for x in returns)) or any(
+                    x is None or np.isnan(x) for x in returns
+                ):
+                    raise ValueError(
+                        f"All elements in the '{Columns.RETURNS.value}' list must be numeric."
+                    )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/decorators/test_dates.py
+++ b/tests/decorators/test_dates.py
@@ -1,0 +1,113 @@
+import pytest
+import pandas as pd
+from portfolio_management.decorators.dates import validate_date_column
+from portfolio_management.constants.columns import Columns
+
+
+@validate_date_column()
+def dummy_function(returns):
+    return "Success"
+
+
+def test_valid_date_column():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            "other_column": [1, 2, 3],
+        }
+    )
+    assert dummy_function(returns=df) == "Success"
+
+
+def test_missing_date_column():
+    df = pd.DataFrame({"other_column": [1, 2, 3]})
+    with pytest.raises(
+        KeyError, match=f"The DataFrame must contain a '{Columns.DATE.value}' column."
+    ):
+        dummy_function(returns=df)
+
+
+def test_incorrect_date_type():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: [
+                "2023-01-01",
+                "2023-01-02",
+                "2023-01-03",
+            ],  # Strings, not datetime
+            "other_column": [1, 2, 3],
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match=f"The '{Columns.DATE.value}' column must be of a datetime type.",
+    ):
+        dummy_function(returns=df)
+
+
+def test_unsorted_dates():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-03", "2023-01-01", "2023-01-02"]
+            ),
+            "other_column": [1, 2, 3],
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match=f"The '{Columns.DATE.value}' column must be sorted in ascending order.",
+    ):
+        dummy_function(returns=df)
+
+
+def test_custom_column_name():
+    @validate_date_column(column_name="custom_date")
+    def custom_dummy_function(returns):
+        return "Success"
+
+    df = pd.DataFrame(
+        {
+            "custom_date": pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"]),
+            "other_column": [1, 2, 3],
+        }
+    )
+    assert custom_dummy_function(returns=df) == "Success"
+
+
+def test_custom_column_name_missing():
+    @validate_date_column(column_name="custom_date")
+    def custom_dummy_function(returns):
+        return "Success"
+
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            "other_column": [1, 2, 3],
+        }
+    )
+    with pytest.raises(
+        KeyError, match="The DataFrame must contain a 'custom_date' column."
+    ):
+        custom_dummy_function(returns=df)
+
+
+def test_returns_as_positional_argument():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            "other_column": [1, 2, 3],
+        }
+    )
+
+    @validate_date_column()
+    def positional_function(returns):
+        return "Success"
+
+    assert positional_function(df) == "Success"

--- a/tests/decorators/test_dates.py
+++ b/tests/decorators/test_dates.py
@@ -111,3 +111,24 @@ def test_returns_as_positional_argument():
         return "Success"
 
     assert positional_function(df) == "Success"
+
+
+def test_returns_as_keyword_argument():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-04", "2023-01-03"]
+            ),
+            "other_column": [1, 2, 3],
+        }
+    )
+
+    @validate_date_column()
+    def keyword_function(*, returns):
+        return "Success"
+
+    with pytest.raises(
+        ValueError,
+        match=f"The '{Columns.DATE.value}' column must be sorted in ascending order.",
+    ):
+        dummy_function(returns=df)

--- a/tests/decorators/test_returns.py
+++ b/tests/decorators/test_returns.py
@@ -1,0 +1,176 @@
+import pytest
+import pandas as pd
+import numpy as np
+from portfolio_management.decorators.returns import validate_returns
+from portfolio_management.constants.columns import Columns
+
+
+@validate_returns()
+def dummy_function(returns):
+    return "Success"
+
+
+def test_valid_dataframe():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: [0.1, 0.2, 0.3],
+        }
+    )
+    assert dummy_function(returns=df) == "Success"
+
+
+def test_missing_returns_column():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            "other_column": [0.1, 0.2, 0.3],
+        }
+    )
+    with pytest.raises(
+        KeyError,
+        match=f"The DataFrame must contain a '{Columns.RETURNS.value}' column.",
+    ):
+        dummy_function(returns=df)
+
+
+def test_non_numeric_returns():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: ["a", "b", "c"],
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match=f"All elements in the '{Columns.RETURNS.value}' column of the DataFrame must be numeric.",
+    ):
+        dummy_function(returns=df)
+
+
+def test_nan_in_returns():
+    df_with_none = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: [0.1, None, 0.3],
+        }
+    )
+    df_with_nan = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: [0.1, np.nan, 0.3],
+        }
+    )
+
+    for df in [df_with_none, df_with_nan]:
+        with pytest.raises(
+            ValueError,
+            match=f"The '{Columns.RETURNS.value}' column in the DataFrame contains NaN or None values.",
+        ):
+            dummy_function(returns=df)
+
+
+def test_valid_series():
+    series = pd.Series([0.1, 0.2, 0.3])
+    assert dummy_function(returns=series) == "Success"
+
+
+def test_nan_in_series():
+    series_with_none = pd.Series([0.1, None, 0.3])
+    series_with_nan = pd.Series([0.1, np.nan, 0.3])
+
+    for series in [series_with_none, series_with_nan]:
+        with pytest.raises(
+            ValueError, match="The 'returns' Series contains NaN or None values."
+        ):
+            dummy_function(returns=series)
+
+
+def test_valid_list():
+    returns_list = [0.1, 0.2, 0.3]
+    assert dummy_function(returns=returns_list) == "Success"
+
+
+def test_non_numeric_list():
+    returns_list = [0.1, "a", 0.3]
+    returns_list_with_none = [0.1, None, 0.3]
+    returns_list_with_nan = [0.1, np.nan, 0.3]
+
+    for returns_list in [returns_list, returns_list_with_none, returns_list_with_nan]:
+        with pytest.raises(
+            ValueError, match="All elements in the 'returns' list must be numeric."
+        ):
+            dummy_function(returns=returns_list)
+
+
+def test_missing_returns_argument():
+    with pytest.raises(
+        ValueError,
+        match="A 'returns' parameter must be provided as a pd.DataFrame, pd.Series, or list.",
+    ):
+        dummy_function(returns=None)
+
+
+def test_check_dates_enabled():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-03", "2023-01-01", "2023-01-02"]
+            ),
+            Columns.RETURNS.value: [0.1, 0.2, 0.3],
+        }
+    )
+
+    @validate_returns(check_dates=True)
+    def check_dates_function(returns):
+        return "Success"
+
+    with pytest.raises(
+        ValueError,
+        match=f"The '{Columns.DATE.value}' column must be sorted in ascending order.",
+    ):
+        check_dates_function(returns=df)
+
+
+def test_check_dates_disabled():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-03", "2023-01-01", "2023-01-02"]
+            ),
+            Columns.RETURNS.value: [0.1, 0.2, 0.3],
+        }
+    )
+
+    @validate_returns(check_dates=False)
+    def no_date_check_function(returns):
+        return "Success"
+
+    assert no_date_check_function(returns=df) == "Success"
+
+
+def test_returns_as_positional_argument():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: [0.1, 0.2, 0.3],
+        }
+    )
+
+    @validate_returns()
+    def positional_function(returns):
+        return "Success"
+
+    assert positional_function(df) == "Success"

--- a/tests/decorators/test_returns.py
+++ b/tests/decorators/test_returns.py
@@ -174,3 +174,24 @@ def test_returns_as_positional_argument():
         return "Success"
 
     assert positional_function(df) == "Success"
+
+
+def test_returns_as_keyword_argument():
+    df = pd.DataFrame(
+        {
+            Columns.DATE.value: pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03"]
+            ),
+            Columns.RETURNS.value: [0.1, None, 0.3],
+        }
+    )
+
+    @validate_returns()
+    def keyword_function(*, returns):
+        return "Success"
+
+    with pytest.raises(
+        ValueError,
+        match=f"The '{Columns.RETURNS.value}' column in the DataFrame contains NaN or None values.",
+    ):
+        dummy_function(returns=df)


### PR DESCRIPTION
Closes #15 

Adds decorator functions for checking returns and dates. 

We can apply the decorators to functions -- see the tests for examples.

The intention is that we can put these on core functions the library to validate data quality. However, we should spend some time using these on actual data before applying as these decorators raise exceptions and are quite intrusive.

We might iterate on these before deeming them good enough to apply to our main functions, which I believe should be created as a separate issue.

